### PR TITLE
탐색 위치와 기본 스캔 대상

### DIFF
--- a/core-java/src/main/java/hello/core/AutoAppConfig.java
+++ b/core-java/src/main/java/hello/core/AutoAppConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.FilterType;
 
 @Configuration
 @ComponentScan(
+        basePackages = "hello.core",
         excludeFilters = @Filter(
                 type = FilterType.ANNOTATION,
                 classes = Configuration.class

--- a/core-kotlin/src/main/kotlin/hello/core/AutoAppConfig.kt
+++ b/core-kotlin/src/main/kotlin/hello/core/AutoAppConfig.kt
@@ -6,9 +6,12 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.FilterType
 
 @Configuration
-@ComponentScan(excludeFilters = [
+@ComponentScan(
+    basePackages = ["hello.core"],
+    excludeFilters = [
     Filter(
         type = FilterType.ANNOTATION,
         classes = [Configuration::class])
-])
+    ]
+)
 class AutoAppConfig


### PR DESCRIPTION
1. `basePackages` 탐색할 패키지의 시작 위치를 지정한다. 이 패키지를 포함해서 하위 패키지를 모두 탐색한다.
2. 만약 지정하지 않으면 `@ComponentScan` 붙은 설정 클래스의 패키지가 시작 위치가 된다.
3. 관례 : 패키지 위치를 지정하지 않고, 설정 정보 클래스의 위치를 프로젝트 최상단에 두는 것