### PR TITLE
조회 빈이 2개 이상 일때

### DIFF
--- a/core-java/build.gradle
+++ b/core-java/build.gradle
@@ -11,12 +11,27 @@ java {
 	sourceCompatibility = '17'
 }
 
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+}
+
 repositories {
 	mavenCentral()
 }
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
+
+	//lombok 라이브러리 추가 시작
+	compileOnly "org.projectlombok:lombok"
+	annotationProcessor "org.projectlombok:lombok"
+
+	testCompileOnly "org.projectlombok:lombok"
+	testAnnotationProcessor "org.projectlombok:lombok"
+	//lombok 라이브러리 추가 끝
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/core-java/src/main/java/hello/core/discount/FixDiscountPolicy.java
+++ b/core-java/src/main/java/hello/core/discount/FixDiscountPolicy.java
@@ -2,7 +2,11 @@ package hello.core.discount;
 
 import hello.core.member.Grade;
 import hello.core.member.Member;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
 
+@Component
+//@Qualifier("fixDiscountPolicy")
 public class FixDiscountPolicy implements DiscountPolicy{
 
     private final int discountFixAmount = 1000;

--- a/core-java/src/main/java/hello/core/discount/RateDiscountPolicy.java
+++ b/core-java/src/main/java/hello/core/discount/RateDiscountPolicy.java
@@ -2,9 +2,13 @@ package hello.core.discount;
 
 import hello.core.member.Grade;
 import hello.core.member.Member;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 @Component
+//@Qualifier("mainDiscountPolicy")
+@Primary
 public class RateDiscountPolicy implements DiscountPolicy {
 
     private static int discountPercent = 10;

--- a/core-java/src/main/java/hello/core/order/OrderServiceImpl.java
+++ b/core-java/src/main/java/hello/core/order/OrderServiceImpl.java
@@ -4,15 +4,24 @@ import hello.core.discount.DiscountPolicy;
 import hello.core.discount.FixDiscountPolicy;
 import hello.core.member.Member;
 import hello.core.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class OrderServiceImpl implements OrderService {
     private final MemberRepository memberRepository;
+    //private final DiscountPolicy rateDiscountPolicy;
     private final DiscountPolicy discountPolicy;
 
-    @Autowired
+    /*
+    public OrderServiceImpl(MemberRepository memberRepository,
+                            @Qualifier("mainDiscountPolicy") DiscountPolicy discountPolicy) {
+        this.memberRepository = memberRepository;
+        this.discountPolicy = discountPolicy;
+    }*/
+
     public OrderServiceImpl(MemberRepository memberRepository, DiscountPolicy discountPolicy) {
         this.memberRepository = memberRepository;
         this.discountPolicy = discountPolicy;

--- a/core-java/src/test/java/hello/core/scan/AutoAppConfigTest.java
+++ b/core-java/src/test/java/hello/core/scan/AutoAppConfigTest.java
@@ -1,7 +1,10 @@
 package hello.core.scan;
 
 import hello.core.AutoAppConfig;
+import hello.core.member.Member;
+import hello.core.member.MemberRepository;
 import hello.core.member.MemberService;
+import hello.core.order.OrderServiceImpl;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
@@ -18,5 +21,9 @@ public class AutoAppConfigTest {
         MemberService memberService = ac.getBean(MemberService.class);
 
         assertThat(memberService).isInstanceOf(MemberService.class);
+
+        OrderServiceImpl bean = ac.getBean(OrderServiceImpl.class);
+        MemberRepository memberRepository = bean.getMemberRepository();
+        System.out.println("memberRepository = " + memberRepository);
     }
 }


### PR DESCRIPTION
1. 필드명, 파라미터 명을 다르게 한다.
2. `@Qualifier` 을 사용한다.
 - `@Qualifier` 에서 못 찾으면 스프링 빈에서 찾고, 없으면, NoSuchBean 예외가 발생한다.
3. `@Primary` 를 지정한다
 - `@Qualifier` 가 `@Primary` 보다 우선 순위가 높다
 - 스프링은 자동보단 수동이, 넓은 범위의 선택권 보다 좁은 범위 선택권이 높다.